### PR TITLE
[FIX] grunt notify 0.4.3 not compatible with node js 6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-import": "0.1.7",
     "grunt-jscs": "2.6.0",
     "grunt-newer": "1.1.1",
-    "grunt-notify": "0.4.3",
+    "grunt-notify": "0.4.5",
     "grunt-postcss": "0.7.1",
     "jshint-stylish": "2.1.0",
     "load-grunt-config": "0.19.1",


### PR DESCRIPTION
grunt notify 0.4.3 not compatible with node js 6.0. Update dependency to 0.4.5 to be able to start grunt. 
