### PR TITLE
podio bug25 fix.

### DIFF
--- a/dev/js/main/header/header.js
+++ b/dev/js/main/header/header.js
@@ -85,9 +85,9 @@ jQuery(function($) {
         $(window).on('load scroll', function() {
             var scrollPos = $(window).scrollTop();
             if (scrollPos > offsetTop) {
-                $('body:not(.main-navigation-fixed)').addClass('main-navigation-fixed');
+                $('body').addClass('main-navigation-fixed');
             } else {
-                $('body.main-navigation-fixed').removeClass('main-navigation-fixed');
+                $('body').removeClass('main-navigation-fixed');
             }
         });
     }

--- a/dev/js/main/header/header.js
+++ b/dev/js/main/header/header.js
@@ -26,10 +26,10 @@ jQuery(function($) {
         $mainNavigationItemsList.removeClass('_open-mobile-dropdown _open-tablet-dropdown');
         $html.removeClass('mobile-menu-opened');
 
-        if (screen.width < 992) {
-            $('.js__navigation__items-wrp').hide();
-        } else {
+        if (window.matchMedia('(min-width: 992px)').matches) {
             $('.js__navigation__items-wrp').show();
+        } else {
+            $('.js__navigation__items-wrp').hide();
         }
     };
 
@@ -37,11 +37,10 @@ jQuery(function($) {
     $openSubMenuLink.on('click', function(e) {
         e.preventDefault();
         // if (touchSupport && $(window).width() > 992) {
-        if ($(window).width() >= 992) {
+        if (window.matchMedia('(min-width: 992px)').matches) {
             $mainNavigationItemsList.not($(this).parents()).removeClass('_open-tablet-dropdown');
             $(this).parents('.main-navigation__item').toggleClass('_open-tablet-dropdown');
-        }
-        if ($(window).width() < 992) {
+        } else {
             $(this).parents('.main-navigation__item').toggleClass('_open-mobile-dropdown');
         }
     });
@@ -71,7 +70,7 @@ jQuery(function($) {
     if (navbar.length) {
         var offsetTop = navbar.offset().top;
         $(window).on('orientationchange',function() {
-            if ($(window).width() >= 992 && touchSupport) {
+            if (window.matchMedia('(min-width: 992px)').matches && touchSupport) {
                 var navbarPos = navbar.css('position');
                 offsetTop = $('header').height() - (navbarPos === 'fixed' ? 0 : navbar.outerHeight());
             }

--- a/dev/js/main/header/header.js
+++ b/dev/js/main/header/header.js
@@ -26,9 +26,7 @@ jQuery(function($) {
         $mainNavigationItemsList.removeClass('_open-mobile-dropdown _open-tablet-dropdown');
         $html.removeClass('mobile-menu-opened');
 
-        if (isAndroid && screen.width < 992 && !$html.hasClass('mobile-menu-opened')) {
-            $('.js__navigation__items-wrp').hide();
-        } else if (!isAndroid /* or with 'isIOS' variable instead of '!isAndroid' */ && $(window).width() < 992 && !$html.hasClass('mobile-menu-opened')) {
+        if (screen.width < 992) {
             $('.js__navigation__items-wrp').hide();
         } else {
             $('.js__navigation__items-wrp').show();

--- a/dev/js/main/header/header.js
+++ b/dev/js/main/header/header.js
@@ -23,15 +23,8 @@ jQuery(function($) {
 
     // Cleanup function to clean unneeded classes
     var cleanup = function cleanup() {
-        if ($mainNavigationItemsList.hasClass('_open-mobile-dropdown')) {
-            $mainNavigationItemsList.removeClass('_open-mobile-dropdown');
-        }
-        if ($mainNavigationItemsList.hasClass('_open-tablet-dropdown')) {
-            $mainNavigationItemsList.removeClass('_open-tablet-dropdown');
-        }
-        if ($html.hasClass('mobile-menu-opened')) {
-            $html.removeClass('mobile-menu-opened');
-        }
+        $mainNavigationItemsList.removeClass('_open-mobile-dropdown _open-tablet-dropdown');
+        $html.removeClass('mobile-menu-opened');
 
         if (isAndroid && screen.width < 992 && !$html.hasClass('mobile-menu-opened')) {
             $('.js__navigation__items-wrp').hide();

--- a/dev/js/main/header/header.js
+++ b/dev/js/main/header/header.js
@@ -37,7 +37,7 @@ jQuery(function($) {
     $openSubMenuLink.on('click', function(e) {
         e.preventDefault();
         // if (touchSupport && $(window).width() > 992) {
-        if ($(window).width() > 992) {
+        if ($(window).width() >= 992) {
             $mainNavigationItemsList.not($(this).parents()).removeClass('_open-tablet-dropdown');
             $(this).parents('.main-navigation__item').toggleClass('_open-tablet-dropdown');
         }
@@ -71,7 +71,7 @@ jQuery(function($) {
     if (navbar.length) {
         var offsetTop = navbar.offset().top;
         $(window).on('orientationchange',function() {
-            if ($(window).width() > 992 && touchSupport) {
+            if ($(window).width() >= 992 && touchSupport) {
                 var navbarPos = navbar.css('position');
                 offsetTop = $('header').height() - (navbarPos === 'fixed' ? 0 : navbar.outerHeight());
             }

--- a/dev/js/main/header/header.js
+++ b/dev/js/main/header/header.js
@@ -22,7 +22,7 @@ jQuery(function($) {
     }
 
     // Cleanup function to clean unneeded classes
-    var cleanup = function cleanup() {
+    var cleanup = function() {
         $mainNavigationItemsList.removeClass('_open-mobile-dropdown _open-tablet-dropdown');
         $html.removeClass('mobile-menu-opened');
 
@@ -69,12 +69,19 @@ jQuery(function($) {
 
     if (navbar.length) {
         var offsetTop = navbar.offset().top;
-        $(window).on('orientationchange',function() {
-            if (window.matchMedia('(min-width: 992px)').matches && touchSupport) {
+
+        // function that calculates offsetTop-value.
+        var calcOffsetTop = function() {
+            if (window.matchMedia('(min-width: 992px)').matches) {
                 var navbarPos = navbar.css('position');
                 offsetTop = $('header').height() - (navbarPos === 'fixed' ? 0 : navbar.outerHeight());
             }
+        };
+
+        $(window).on('orientationchange',function() {
+            calcOffsetTop();
         });
+
         $(window).on('load scroll', function() {
             var scrollPos = $(window).scrollTop();
             if (scrollPos > offsetTop) {

--- a/dev/js/main/header/header.js
+++ b/dev/js/main/header/header.js
@@ -36,7 +36,7 @@ jQuery(function($) {
     // Add click event to dropdown link on mobile devices.
     $openSubMenuLink.on('click', function(e) {
         e.preventDefault();
-        // if (touchSupport && $(window).width() > 992) {
+        
         if (window.matchMedia('(min-width: 992px)').matches) {
             $mainNavigationItemsList.not($(this).parents()).removeClass('_open-tablet-dropdown');
             $(this).parents('.main-navigation__item').toggleClass('_open-tablet-dropdown');
@@ -45,9 +45,8 @@ jQuery(function($) {
         }
     });
 
-    $(window).on('orientationchange',function() {
-        cleanup();
-    });
+    // detect if we cross 992px window width.
+    window.matchMedia('(min-width: 992px)').addListener(cleanup);
 
     var mobileMenuAnimationComplete = true;
     $('.js__main-navigation__toggle-btn').on('click', function(e) {
@@ -78,9 +77,8 @@ jQuery(function($) {
             }
         };
 
-        $(window).on('orientationchange',function() {
-            calcOffsetTop();
-        });
+        // detect if we cross 992px window width.
+        window.matchMedia('(min-width: 992px)').addListener(calcOffsetTop);
 
         $(window).on('load scroll', function() {
             var scrollPos = $(window).scrollTop();


### PR DESCRIPTION
I broke it down to small commits to explain exactly what I was doing.

I've found (thanks to V. Husaruk) that using **window.matchMedia** seems to be the best way of doing Bootstrap window width-changes. It's supported since IE10 etc, https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia

It seems consistent to report like the browser is (taking the appearance of the scrollbar into consideration, whether it's floating or on the side and thus minimizing the width area). That's why orientationchange was replaced with this because it will still fire if you change the orientation of your device and it crosses the width that we're concerned about.

I've not had these issues since changing the code:
- main_navigation hidden when starting in < 992 and then expanding window >= 992 pixels width.
- "Fixed menu looks buggy when scrolling".
- Any glitches around the 992 pixel width.

I've tested Linux Chrome, Linux Firefox and Windows 7 IE11 but we should test mobile and Safari too.