### PR TITLE
no space between pagination and footer on search page (Podio bug_35)

### DIFF
--- a/dev/styles/main/plugins/search/search.less
+++ b/dev/styles/main/plugins/search/search.less
@@ -62,7 +62,7 @@
 }
 
 .search-result-pagination:last-child {
-  margin-bottom: 20px;
+    margin-bottom: 20px;
 }
 
 .search-result-pagination .btn-default {

--- a/dev/styles/main/plugins/search/search.less
+++ b/dev/styles/main/plugins/search/search.less
@@ -60,6 +60,11 @@
 .search-result-pagination {
     margin-top: 20px;
 }
+
+.search-result-pagination:last-child {
+  margin-bottom: 20px;
+}
+
 .search-result-pagination .btn-default {
     background: darken(@main-body-bg, 10%);
     color: @main-text-color;


### PR DESCRIPTION
<img width="888" alt="screen shot 2016-12-12 at 16 54 13" src="https://cloud.githubusercontent.com/assets/17538897/21104391/07045256-c08f-11e6-906e-022e012a8664.png">

add 20px of space between pagination and footer of search page 